### PR TITLE
Fix dead link to DHRI command line glossary

### DIFF
--- a/book/01-Command-Line/01-The-Command-Line.html
+++ b/book/01-Command-Line/01-The-Command-Line.html
@@ -116,7 +116,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <p class="title">
 Note
 </p>
-<p>Technically speaking, <em>command line</em>, <em>shell</em>, <em>bash</em>, and <em>terminal</em> all mean slightly different things. The Digital Humanities Research Institute provides <a href="https://github.com/DHRI-Curriculum/glossary/blob/master/sections/command-line.md#glossary">a helpful primer on the distinctions</a>.</p>
+<p>Technically speaking, <em>command line</em>, <em>shell</em>, <em>bash</em>, and <em>terminal</em> all mean slightly different things. The Digital Humanities Research Institute provides <a href="https://github.com/DHRI-Curriculum/glossary/blob/v2.0/terms/command-line.md">a helpful primer on the distinctions</a>.</p>
 </div>
 <p>The command line interface is often contrasted with the graphical user interface or GUI (pronounced <em>gooey</em>, like <a href="https://en.wikipedia.org/wiki/Gooey_butter_cake">St.&nbsp;Louis gooey butter cake</a>). This is the way that most people are familiar with navigating their computers.</p>
 <p>To illustrate the difference between the command line and the GUI, consider the following example. I want to make a new folder to organize my notes for this class. So I drag my mouse cursor and click on a button that says “New Folder,” which makes a small icon of a folder appear. I title this folder “Intro-CA-Notes.” Now I want to delete this folder. So I drag and drop the folder icon into a tiny trash can icon.</p>

--- a/book/01-Command-Line/01-The-Command-Line.ipynb
+++ b/book/01-Command-Line/01-The-Command-Line.ipynb
@@ -36,7 +36,7 @@
    "source": [
     "<div class=\"admonition note\" name=\"html-admonition\" style=\"background: lightblue; padding: 10px\">\n",
     "<p class=\"title\">Note</p>\n",
-    "Technically speaking, *command line*, *shell*, *bash*, and *terminal* all mean slightly different things. The Digital Humanities Research Institute provides [a helpful primer on the distinctions](https://github.com/DHRI-Curriculum/glossary/blob/master/sections/command-line.md#glossary).\n",
+    "Technically speaking, *command line*, *shell*, *bash*, and *terminal* all mean slightly different things. The Digital Humanities Research Institute provides [a helpful primer on the distinctions](https://github.com/DHRI-Curriculum/glossary/blob/v2.0/terms/command-line.md).\n",
     "</div>\n",
     "\n",
     "The command line interface is often contrasted with the graphical user interface or GUI (pronounced *gooey*, like [St. Louis gooey butter cake](https://en.wikipedia.org/wiki/Gooey_butter_cake)). This is the way that most people are familiar with navigating their computers. \n",


### PR DESCRIPTION
Updated [link](https://github.com/DHRI-Curriculum/glossary/blob/v2.0/terms/command-line.md) to the Digital Humanities Research Institute's primer on terms relating to the CLI.

Resolves #41.